### PR TITLE
Remove dependency on `unstable/pretty`

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,12 +1,12 @@
 Nanopass Compiler Library
 ==========================
 
-This repositiory contains a Racket version of the Nanopass Compiler Infrastructure
-described in \[1, 2, 3, 4\], along with the beginnings of a test compiler for the
-library and the rough start to a users guide.  The nanopass framework for Racket
-has been tested on Racket version 6.0, 6.1, and the current development version.
-An R6RS Scheme version also exists which support Chez Scheme, Vicare Scheme, and
-Ikarus Scheme.
+This repositiory contains a Racket version of the Nanopass Compiler
+Infrastructure described in \[1, 2, 3, 4\], along with the beginnings of a test
+compiler for the library and the rough start to a users guide.  The nanopass
+framework for Racket has been tested on Racket version 6.0, 6.1, 6.2, and the
+current development version.  An R6RS Scheme version also exists which support
+Chez Scheme, Vicare Scheme, and Ikarus Scheme.
 
 Files
 ======

--- a/info.rkt
+++ b/info.rkt
@@ -4,8 +4,7 @@
 
 (define deps '("base"
                "rackunit-lib"
-               "compatibility-lib"
-               "unstable-pretty-lib"))
+               "compatibility-lib"))
 (define build-deps '("scribble-lib"
                      "racket-doc"))
 (define scribblings '(("doc/user-guide.scrbl")))

--- a/private/language.rkt
+++ b/private/language.rkt
@@ -25,7 +25,7 @@
                       racket/list
                       syntax/stx
                       syntax/parse
-                      unstable/pretty
+                      racket/pretty
                       "helpers.rkt"
                       "language-helpers.rkt"
                       "records.rkt"
@@ -404,7 +404,7 @@
                                   (syntax-span lang))
                                (format "Language ~a:~n~a"
                                        (syntax-e lang)
-                                       (pretty-format/write
+                                       (pretty-format #:mode 'write
                                         (language->s-expression-internal desc)))))))
 
   (syntax-case x ()

--- a/private/pass.rkt
+++ b/private/pass.rkt
@@ -22,7 +22,6 @@
                      syntax/parse
                      racket/base
                      racket/pretty
-                     unstable/pretty
                      "helpers.rkt"
                      "records.rkt"
                      "syntaxconvert.rkt"
@@ -80,7 +79,7 @@
                    -1)
                 (format "Language ~a:~n~a"
                         (syntax-e #'lang)
-                        (pretty-format/write
+                        (pretty-format #:mode 'write
                          (language->s-expression-internal olang))))))]
       [(id lang b b* ...)
        #:with in-context (datum->syntax #'id 'in-context)
@@ -104,7 +103,7 @@
                    -1)
                 (format "Language ~a:~n~a"
                         (syntax-e #'lang)
-                        (pretty-format/write
+                        (pretty-format #:mode 'write
                          (language->s-expression-internal olang))))))]))
 
 (define-syntax (nanopass-case x)
@@ -133,7 +132,7 @@
                    -1)
                 (format "Language ~a:~n~a"
                         (syntax-e #'lang)
-                        (pretty-format/write
+                        (pretty-format #:mode 'write
                          (language->s-expression-internal olang))))))]
     [(k (lang type) e cl ... [else b0 b1 ...])
      (let* ([olang-pair (lookup-language 'with-output-language "unrecognized language name" #'lang)]
@@ -150,7 +149,7 @@
                    -1)
                 (format "Language ~a:~n~a"
                         (syntax-e #'lang)
-                        (pretty-format/write
+                        (pretty-format #:mode 'write
                          (language->s-expression-internal olang))))))]
     [(k (lang type) e cl ...)
      (let* ([olang-pair (lookup-language 'with-output-language "unrecognized language name" #'lang)]
@@ -174,7 +173,7 @@
                    -1)
                 (format "Language ~a:~n~a"
                         (syntax-e #'lang)
-                        (pretty-format/write
+                        (pretty-format #:mode 'write
                          (language->s-expression-internal olang))))))]))
 
 (define-syntax trace-define-pass
@@ -1618,7 +1617,7 @@
                                   -1)
                                (format "Language ~a:~n~a"
                                        (syntax-e maybe-iname)
-                                       (pretty-format/write
+                                       (pretty-format #:mode 'write
                                         (language->s-expression-internal maybe-ilang)))))
                   (and maybe-oname maybe-olang
                        (vector maybe-oname
@@ -1628,7 +1627,7 @@
                                   -1)
                                (format "Language ~a:~n~a"
                                        (syntax-e maybe-oname)
-                                       (pretty-format/write
+                                       (pretty-format #:mode 'write
                                         (language->s-expression-internal maybe-olang)))))))))))))
 
     (syntax-case x ()


### PR DESCRIPTION
Requires Racket 6.2.900.15.

Not sure how the other commit got there.
